### PR TITLE
Add FilesAcls + DatasetsAcls checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This action deploys a Python function to Cognite Functions, optionally with sche
 
 #### Optional
 1. `remove_only`: **Short-cut**: Deletes function along with all attached schedules. Ignores most other parameters!
-1. `common_folder`:  The path to the folder containing code that is shared between all functions. Defaults to `common/`. More information in section below.
+1. `common_folder`:  The path to the folder containing code that is shared between functions. See section below for more details.
 1. `function_file`: The name of the file with your main function. Will default to `handler.py` if not given.
 1. `function_secrets`: The *name* of a Github secret that holds the base64-encoded JSON dictionary with secrets (see "secrets section").
-1. `data_set_external_id`: Data set external ID (for FilesAPI) to use for the function-associated file (zipped code folder). Requires two *additional* DEPLOYMENT capabilities: 'dataset:READ' and 'files:WRITE' scoped to *either* the dataset you are going to use, or 'all'. Note: If your data set is WRITE PROTECTED, you also need to add the capability 'dataset:OWNER' for it. Read more about data sets in the official documentation: [Data sets](https://docs.cognite.com/cdf/data_governance/concepts/datasets/)
+1. `data_set_id`: Data set ID to use for the file uploaded to CDF (the function-associated file: *zipped code folder*). Requires two *additional* DEPLOYMENT capabilities: 'dataset:READ' and 'files:WRITE' scoped to *either* the dataset you are going to use, or 'all'. Note: If your data set is WRITE PROTECTED, you also need to add the capability 'dataset:OWNER' for it. Read more about data sets in the official documentation: [Data sets](https://docs.cognite.com/cdf/data_governance/concepts/datasets/)
 1. `description`: Additional field to describe the function.
 1. `owner`: Additional field to describe the function owner.
 1. `cpu`: Set fractional number of CPU cores per function. **Ignored for functions running on Azure!**. See defaults and allowed values in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).

--- a/action.yaml
+++ b/action.yaml
@@ -57,8 +57,8 @@ inputs:
             all existing schedules are deleted (and recreated if there are any)! Note: Requires
             'schedules_client_secret', 'schedules_tenant_id' and 'schedules_client_id' to be passed!
         required: false
-    data_set_external_id:
-        description: Data set external ID to use for the function-associated file (zipped code folder).
+    data_set_id:
+        description: Data set ID to use for the file uploaded to CDF (the function-associated file, i.e. the zipped code folder)
         required: false
     common_folder:
         description: |

--- a/src/access.py
+++ b/src/access.py
@@ -1,18 +1,21 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import Dict, Iterable, Iterator, List
+from os import linesep
+from typing import Any, Dict, Iterable, Iterator, List
 
 from cognite.client.data_classes.iam import TokenInspection
 from cognite.client.exceptions import CogniteAPIError
+from cognite.experimental import CogniteClient
 
-from utils import create_oidc_client_from_dct
+from utils import retrieve_dataset
 
 logger = logging.getLogger(__name__)
 
 
-def verify_credentials_vs_project(creds: Dict[str, object], project: str, cred_name: str) -> TokenInspection:
+def verify_credentials_vs_project(client: CogniteClient, project: str, cred_name: str) -> TokenInspection:
     try:
-        client = create_oidc_client_from_dct(creds)
         token_inspect = client.iam.token.inspect()
     except CogniteAPIError:
         raise ValueError(
@@ -34,37 +37,81 @@ class Capability:
     acl: str
     version: int
     actions: List[str]
-    scope: Dict[str, object]
+    scope: Dict[str, Any]
     projects: List[str]
 
     @classmethod
-    def from_dict(cls, dct):
+    def from_dict(cls, dct: Dict[str, Any]) -> Capability:
         projects = dct.pop("projectScope")["projects"]
         (acl,) = dct  # magic voodoo syntax to extract the only key
         return cls(acl=acl, projects=projects, **dct[acl])
+
+    def is_all_scope(self) -> bool:
+        return "all" in self.scope
+
+    def is_dataset_scope(self, id: int) -> bool:
+        return id in self.scope.get("datasetScope", {}).get("ids", [])
+
+    def is_ids_scope(self, id: int) -> bool:
+        return id in self.scope.get("idScope", {}).get("ids", [])
 
 
 def filter_capabilities(capabilities: Iterable[Capability], acl: str) -> Iterator[Capability]:
     return filter(lambda c: c.acl == acl, capabilities)
 
 
-def missing_function_capabilities(capabilities: Iterable[Capability]):
+def missing_function_capabilities(capabilities: Iterable[Capability]) -> List[str]:
     actions = set(a for c in filter_capabilities(capabilities, acl="functionsAcl") for a in c.actions)
     if missing := set(["READ", "WRITE"]) - actions:
-        return [f"Functions:{m}" for m in missing]
+        return [f"FunctionsAcl:{m} (scope: 'all')" for m in missing]
     return []
 
 
-def missing_files_capabilities(capabilities: Iterable[Capability]):
-    # files_capes = list(filter_capabilities(capabilities, acl="filesAcl"))
-    # TODO: Implement!
-    logger.info("FilesAcl capabilities not verified! Reason: Not implemented yet ;)")
-    return []
+def missing_files_capabilities(
+    capabilities: Iterable[Capability], client: CogniteClient, ds_id: int = None
+) -> List[str]:
+    files_capes = list(filter_capabilities(capabilities, acl="filesAcl"))
+    files_actions_all_scope = set(a for c in files_capes for a in c.actions if c.is_all_scope())
+    missing_files_acl = set(["READ", "WRITE"]) - files_actions_all_scope
+
+    if ds_id is None:
+        # Not using a data set, so we require Files:READ/WRITE in scope=ALL:
+        if missing_files_acl:
+            return [f"FilesAcl:{m} (scope: 'all') (Tip: consider using a data set!)" for m in missing_files_acl]
+        return []
+
+    # If using a data set, we also accept *it* as scope for files:
+    missing_acls = []
+    files_actions_dsid_scope = set(a for c in files_capes for a in c.actions if c.is_dataset_scope(ds_id))
+    if missing_files_acl := missing_files_acl - files_actions_dsid_scope:
+        missing_acls += [f"FilesAcl:{m} (scope: 'all' OR 'dataset: {ds_id}')" for m in missing_files_acl]
+
+    data_set_capes = filter_capabilities(capabilities, acl="datasetsAcl")
+    data_set_actions = set(a for c in data_set_capes for a in c.actions if c.is_all_scope() or c.is_ids_scope(ds_id))
+    if "READ" not in data_set_actions:
+        # No read access to the given data set, so we can't check if it is write protected:
+        missing_acls.append(f"DatasetsAcl:READ (scope: 'all' OR 'id: {ds_id}')")
+        if "OWNER" not in data_set_actions:
+            missing_acls.append("(If dataset is write protected, you'll also need OWNER)")
+        return missing_acls
+
+    if retrieve_dataset(client, ds_id).write_protected:
+        if "OWNER" not in data_set_actions:
+            missing_acls.append(f"DatasetsAcl:OWNER (scope: 'all' OR 'id: {ds_id}'). NB: 'all scope' not recommended!")
+    return missing_acls
 
 
-def verify_capabilites(token_inspect: TokenInspection, project: str, cred_name: str) -> None:
+def verify_capabilites(
+    token_inspect: TokenInspection,
+    client: CogniteClient,
+    project: str,
+    ds_id: int = None,
+) -> None:
     capabilities = list(filter(lambda c: project in c.projects, map(Capability.from_dict, token_inspect.capabilities)))
-    missing = missing_function_capabilities(capabilities) + missing_files_capabilities(capabilities)
+    missing = missing_function_capabilities(capabilities) + missing_files_capabilities(capabilities, client, ds_id)
     if missing:
-        raise ValueError(f"{cred_name.title()} credentials missing one or more required capabilities: {missing}")
-    logger.info(f"{cred_name.title()} credentials capabilities verified!")
+        err_msg = f"Deploy credentials missing one or more required capabilities:\n{linesep.join(missing)}"
+        logger.error(err_msg)
+        raise ValueError(err_msg)
+
+    logger.info("Deploy credentials capabilities verified!")

--- a/src/configs.py
+++ b/src/configs.py
@@ -1,5 +1,4 @@
 import logging
-from contextlib import suppress
 from os import getenv
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -77,12 +76,15 @@ class DeployCredentials(GithubActionModel, CredentialsModel):
     client_id: NonEmptyString = Field(alias="deployment_client_id")
     tenant_id: NonEmptyString = Field(alias="deployment_tenant_id")
     client_secret: NonEmptyString = Field(alias="deployment_client_secret")
+    data_set_id: Optional[int]  # For acl/capability checks only
 
     @root_validator(skip_on_failure=True)
     def verify_credentials_and_capabilities(cls, values):
+        client = create_oidc_client_from_dct(values)
         project = values["cdf_project"]
-        token_inspect = verify_credentials_vs_project(values, project, cred_name="deploy")
-        verify_capabilites(token_inspect, project, cred_name="deploy")
+        token_inspect = verify_credentials_vs_project(client, project, cred_name="deploy")
+        data_set_id = values["data_set_id"]
+        verify_capabilites(token_inspect, client, project, data_set_id=data_set_id)
         return values
 
 
@@ -106,7 +108,8 @@ class SchedulesConfig(GithubActionModel, CredentialsModel):
                 "Schedules created for OIDC functions require additional client credentials (to be used  at runtime). "
                 "Missing one or more of ['schedules_client_secret', 'schedules_client_id', 'schedules_tenant_id']"
             )
-        verify_credentials_vs_project(values, cred_name="schedule")
+        client = create_oidc_client_from_dct(values)
+        verify_credentials_vs_project(client, project=values["cdf_project"], cred_name="schedule")
         return values
 
 
@@ -116,7 +119,7 @@ class FunctionConfig(GithubActionModel):
     function_secrets: Optional[Dict[str, str]]
     function_file: FnFileString
     common_folder: Optional[Path]
-    data_set_external_id: Optional[str]
+    data_set_id: Optional[int]
     cpu: Optional[float]
     memory: Optional[float]
     owner: Optional[NonEmptyStringMax128]
@@ -150,12 +153,10 @@ class FunctionConfig(GithubActionModel):
     def check_function_folders(cls, values):
         verify_path_is_directory(values["function_folder"], "function_folder")
 
-        if (common_folder := values["common_folder"]) is not None:
-            verify_path_is_directory(common_folder, "common_folder")
+        if (common_folder := values["common_folder"]) is None:
+            logger.info("No 'common code' directory added to the function!")
         else:
-            # Try default directory 'common/':
-            with suppress(ValueError):
-                values["common_folder"] = verify_path_is_directory(Path("common"), "common")
+            verify_path_is_directory(common_folder, "common_folder")
         return values
 
 

--- a/src/function_file.py
+++ b/src/function_file.py
@@ -25,37 +25,20 @@ def _write_files_to_zip_buffer(zf: ZipFile, directory: Path):
 def upload_zipped_code_to_files(
     client: CogniteClient,
     file_bytes: bytes,
-    name: str,
+    xid: str,
     ds: DataSet,
 ) -> FileMetadata:
-    try:
-        return client.files.upload_bytes(
-            file_bytes,
-            name=name,
-            external_id=name,
-            data_set_id=ds.id,
-            overwrite=True,
-        )
-    except CogniteAPIError as exc:
-        if ds.id is None:
-            # Error is not dataset related, so we immediately re-raise
-            raise
-        if ds.write_protected:
-            err_msg = (
-                "Unable to upload file to WRITE-PROTECTED dataset: Deployment credentials MUST have capability "
-                "'dataset:OWNER' (and have 'files:WRITE' scoped to the same dataset OR all files)."
-            )
-        else:
-            err_msg = (
-                "Unable to upload file to dataset: Deployment credentials must have capability "
-                "'files:WRITE' scoped to the same dataset OR all files."
-            )
-        logger.error(err_msg)
-        raise CogniteAPIError(err_msg, exc.code, exc.x_request_id) from None
+    return client.files.upload_bytes(
+        file_bytes,
+        name=xid,
+        external_id=xid,
+        data_set_id=ds.id,
+        overwrite=True,
+    )
 
 
-def zip_and_upload_folder(client: CogniteClient, fn_config: FunctionConfig, name: str) -> int:
-    logger.info(f"Uploading code from '{fn_config.function_folder}' to '{name}'")
+def zip_and_upload_folder(client: CogniteClient, fn_config: FunctionConfig, xid: str) -> int:
+    logger.info(f"Uploading code from '{fn_config.function_folder}' to Files using external ID: '{xid}'")
     buf = io.BytesIO()  # TempDir, who needs that?! :rocket:
     with ZipFile(buf, mode="a") as zf:
         with temporary_chdir(fn_config.function_folder):
@@ -66,20 +49,21 @@ def zip_and_upload_folder(client: CogniteClient, fn_config: FunctionConfig, name
                 logger.info(f"- Added common directory: '{common_folder}' to the file/function")
                 _write_files_to_zip_buffer(zf, directory=common_folder)
 
-    if (ds_xid := fn_config.data_set_external_id) is not None:
-        ds = retrieve_dataset(client, ds_xid)
+    if (ds_id := fn_config.data_set_id) is not None:
+        ds = retrieve_dataset(client, ds_id)
         logger.info(
-            f"- Using dataset '{ds.external_id}' to govern the file (has write protection: {ds.write_protected})."
+            f"- Using dataset '{ds.external_id}' (ID: {ds_id}) to govern the file "
+            f"(has write protection: {ds.write_protected})."
         )
     else:
         ds = DataSet(id=None)
         logger.info("- No dataset will be used to govern the function zip-file!")
 
-    file_meta = upload_zipped_code_to_files(client, buf.getvalue(), name, ds)
+    file_meta = upload_zipped_code_to_files(client, buf.getvalue(), xid, ds)
     if (file_id := file_meta.id) is not None:
-        logger.info(f"- File uploaded successfully ({name})!")
+        logger.info(f"- File uploaded successfully ({xid})!")
         return file_id
-    raise FunctionDeployError(f"Failed to upload file ({name}) to CDF Files")
+    raise FunctionDeployError(f"Failed to upload file ({xid}) to CDF Files")
 
 
 def delete_function_file(client: CogniteClient, xid: str):
@@ -91,12 +75,8 @@ def delete_function_file(client: CogniteClient, xid: str):
     try:
         client.files.delete(external_id=xid)
         logger.info(f"- Delete of file '{xid}' successful!")
-    except CogniteAPIError:
-        if file_meta.data_set_id is None:
-            raise  # File is not protected by dataset, so we re-raise immediately
+    except CogniteAPIError as err:
         logger.error(
-            f"Unable to delete file! It is governed by data set with ID: {file_meta.data_set_id}. "
-            "Make sure your deployment credentials have write/owner access (see README.md in "
-            "function-action repo). Trying to ignore and continue as this workflow will "
+            f"Unable to delete file, reason: {err!r}! Trying to ignore and continue as this action will "
             "overwrite the file later."
         )

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 from cognite.client.data_classes import DataSet
-from cognite.client.exceptions import CogniteAPIError
 from cognite.experimental import CogniteClient
 from pydantic import constr
 
@@ -49,17 +48,11 @@ def verify_path_is_directory(path: Path, parameter: str) -> Path:
     return path
 
 
-def retrieve_dataset(client: CogniteClient, xid: str) -> DataSet:
-    try:
-        # Patiently awaiting FilesAPI support of dataset xids...
-        if ds := client.data_sets.retrieve(external_id=xid):
-            return ds
-        raise ValueError(f"No dataset exists with external ID: '{xid}'")
-
-    except CogniteAPIError as exc:
-        err_msg = "Unable to retrieve dataset: Deployment credentials is missing capability 'dataset:READ'."
-        logger.error(err_msg)
-        raise CogniteAPIError(err_msg, exc.code, exc.x_request_id) from None
+@lru_cache(None)
+def retrieve_dataset(client: CogniteClient, id: int) -> DataSet:
+    if ds := client.data_sets.retrieve(id):
+        return ds
+    raise ValueError(f"No dataset exists with ID: '{id}'")
 
 
 @lru_cache(None)


### PR DESCRIPTION
Minor update:
- Because of how capabilities (through groups) are returned (scope), we have to ask for the data set by ID instead of external ID... fml. 
- No way to *not* get common code folder added to your function if it was named `common`. This is now fixed with no default value.

Major update:
- All previous dataset + files checks have now moved to be part of config validation, instead of failing halfway through the function action at runtime. Where possible, all necessary but lacking capabilities are listed to the user.

**Timeline**: as soon as possible but not like "asap" 😜 
**Feedback level**: bullet-proof pliiiiz