### PR TITLE
Actually fix acls

### DIFF
--- a/src/access.py
+++ b/src/access.py
@@ -4,7 +4,7 @@ import logging
 from contextlib import suppress
 from dataclasses import dataclass
 from os import linesep
-from typing import Any, Dict, Iterable, Iterator, List, NoReturn
+from typing import AbstractSet, Any, Dict, Iterable, Iterator, List, NoReturn
 
 from cognite.client.data_classes.iam import TokenInspection
 from cognite.client.exceptions import CogniteAPIError
@@ -56,8 +56,8 @@ def retrieve_and_parse_capabilities(client: CogniteClient, project: str) -> List
     )
 
 
-def filter_capabilities(capabilities: Iterable[Capability], acl: str) -> Iterator[Capability]:
-    return filter(lambda c: c.acl == acl, capabilities)
+def filter_capabilities(capabs: Iterable[Capability], acl: str) -> Iterator[Capability]:
+    return filter(lambda c: c.acl == acl, capabs)
 
 
 ACL_PROJECT_LIST = "projects:LIST (scope: 'all')"
@@ -81,24 +81,24 @@ def missing_basic_capabilities(client: CogniteClient) -> List[str]:
     return [ACL_GROUPS_LIST, MISSING_ACLS_WARNING]
 
 
-def missing_function_capabilities(capabilities: Iterable[Capability]) -> List[str]:
-    actions = set(a for c in filter_capabilities(capabilities, acl="functionsAcl") for a in c.actions)
-    if missing := set(["READ", "WRITE"]) - actions:
+def missing_function_capabilities(
+    capabs: Iterable[Capability], required_actions: AbstractSet = frozenset(("READ", "WRITE"))
+) -> List[str]:
+    actions = set(a for c in filter_capabilities(capabs, acl="functionsAcl") for a in c.actions)
+    if missing := required_actions - actions:
         return [f"functionsAcl:{m} (scope: 'all')" for m in missing]
     return []
 
 
-def missing_session_capabilities(capabilities: Iterable[Capability]) -> List[str]:
-    actions = set(a for c in filter_capabilities(capabilities, acl="sessionsAcl") for a in c.actions)
+def missing_session_capabilities(capabs: Iterable[Capability]) -> List[str]:
+    actions = set(a for c in filter_capabilities(capabs, acl="sessionsAcl") for a in c.actions)
     if "CREATE" not in actions:
         return ["sessionsAcl:CREATE (scope: 'all')"]
     return []
 
 
-def missing_files_capabilities(
-    capabilities: Iterable[Capability], client: CogniteClient, ds_id: int = None
-) -> List[str]:
-    files_capes = list(filter_capabilities(capabilities, acl="filesAcl"))
+def missing_files_capabilities(capabs: Iterable[Capability], client: CogniteClient, ds_id: int = None) -> List[str]:
+    files_capes = list(filter_capabilities(capabs, acl="filesAcl"))
     files_actions_all_scope = set(a for c in files_capes for a in c.actions if c.is_all_scope())
     missing_files_acl = set(["READ", "WRITE"]) - files_actions_all_scope
 
@@ -114,7 +114,7 @@ def missing_files_capabilities(
     if missing_files_acl := missing_files_acl - files_actions_dsid_scope:
         missing_acls += [f"filesAcl:{m} (scope: 'all' OR 'dataset: {ds_id}')" for m in missing_files_acl]
 
-    data_set_capes = filter_capabilities(capabilities, acl="datasetsAcl")
+    data_set_capes = filter_capabilities(capabs, acl="datasetsAcl")
     data_set_actions = set(a for c in data_set_capes for a in c.actions if c.is_all_scope() or c.is_ids_scope(ds_id))
     if "READ" not in data_set_actions:
         # No read access to the given data set, so we can't check if it is write protected:
@@ -129,13 +129,20 @@ def missing_files_capabilities(
     return missing_acls
 
 
-def verify_schedule_creds_capabilities(client: CogniteClient, project: str) -> TokenInspection:
+def check_basics_and_retrieve_capabilities(client: CogniteClient, project: str, cred_name: str) -> List[Capability]:
     if missing_basic := missing_basic_capabilities(client):
-        raise_on_missing(missing_basic, "schedule")
+        raise_on_missing(missing_basic, cred_name)
 
-    capabilities = retrieve_and_parse_capabilities(client, project)
-    if missing := missing_session_capabilities(capabilities):
-        raise_on_missing(missing, "schedule")
+    return retrieve_and_parse_capabilities(client, project)
+
+
+def verify_schedule_creds_capabilities(
+    client: CogniteClient, project: str, cred_name: str = "schedule"
+) -> TokenInspection:
+    capabs = check_basics_and_retrieve_capabilities(client, project, cred_name)
+    missing = missing_function_capabilities(capabs, required_actions={"WRITE"}) + missing_session_capabilities(capabs)
+    if missing:
+        raise_on_missing(missing, cred_name)
     logger.info("Schedule credentials capabilities verified!")
 
 
@@ -143,18 +150,12 @@ def verify_deploy_capabilites(
     client: CogniteClient,
     project: str,
     ds_id: int = None,
+    cred_name: str = "deploy",
 ):
-    if missing_basic := missing_basic_capabilities(client):
-        raise_on_missing(missing_basic, "deploy")
-
-    capabilities = retrieve_and_parse_capabilities(client, project)
-    missing = (
-        missing_function_capabilities(capabilities)
-        + missing_files_capabilities(capabilities, client, ds_id)
-        + missing_session_capabilities(capabilities)
-    )
+    capabs = check_basics_and_retrieve_capabilities(client, project, cred_name)
+    missing = missing_function_capabilities(capabs) + missing_files_capabilities(capabs, client, ds_id)
     if missing:
-        raise_on_missing(missing, "deploy")
+        raise_on_missing(missing, cred_name)
     logger.info("Deploy credentials capabilities verified!")
 
 

--- a/src/access.py
+++ b/src/access.py
@@ -86,14 +86,14 @@ def missing_function_capabilities(
 ) -> List[str]:
     actions = set(a for c in filter_capabilities(capabs, acl="functionsAcl") for a in c.actions)
     if missing := required_actions - actions:
-        return [f"functionsAcl:{m} (scope: 'all')" for m in missing]
+        return [f"FunctionsAcl:{m} (scope: 'all')" for m in missing]
     return []
 
 
 def missing_session_capabilities(capabs: Iterable[Capability]) -> List[str]:
     actions = set(a for c in filter_capabilities(capabs, acl="sessionsAcl") for a in c.actions)
     if "CREATE" not in actions:
-        return ["sessionsAcl:CREATE (scope: 'all')"]
+        return ["SessionsAcl:CREATE (scope: 'all')"]
     return []
 
 
@@ -105,27 +105,27 @@ def missing_files_capabilities(capabs: Iterable[Capability], client: CogniteClie
     if ds_id is None:
         # Not using a data set, so we require Files:READ/WRITE in scope=ALL:
         if missing_files_acl:
-            return [f"filesAcl:{m} (scope: 'all') (Tip: consider using a data set!)" for m in missing_files_acl]
+            return [f"FilesAcl:{m} (scope: 'all') (Tip: consider using a data set!)" for m in missing_files_acl]
         return []
 
     # If using a data set, we also accept *it* as scope for files:
     missing_acls = []
     files_actions_dsid_scope = set(a for c in files_capes for a in c.actions if c.is_dataset_scope(ds_id))
     if missing_files_acl := missing_files_acl - files_actions_dsid_scope:
-        missing_acls += [f"filesAcl:{m} (scope: 'all' OR 'dataset: {ds_id}')" for m in missing_files_acl]
+        missing_acls += [f"FilesAcl:{m} (scope: 'all' OR 'dataset: {ds_id}')" for m in missing_files_acl]
 
     data_set_capes = filter_capabilities(capabs, acl="datasetsAcl")
     data_set_actions = set(a for c in data_set_capes for a in c.actions if c.is_all_scope() or c.is_ids_scope(ds_id))
     if "READ" not in data_set_actions:
         # No read access to the given data set, so we can't check if it is write protected:
-        missing_acls.append(f"datasetsAcl:READ (scope: 'all' OR 'id: {ds_id}')")
+        missing_acls.append(f"DatasetsAcl:READ (scope: 'all' OR 'id: {ds_id}')")
         if "OWNER" not in data_set_actions:
             missing_acls.append("(If dataset is write protected, you'll also need OWNER)")
         return missing_acls
 
     if retrieve_dataset(client, ds_id).write_protected:
         if "OWNER" not in data_set_actions:
-            missing_acls.append(f"datasetsAcl:OWNER (scope: 'all' OR 'id: {ds_id}'). NB: 'all scope' not recommended!")
+            missing_acls.append(f"DatasetsAcl:OWNER (scope: 'all' OR 'id: {ds_id}'). NB: 'all scope' not recommended!")
     return missing_acls
 
 

--- a/src/index.py
+++ b/src/index.py
@@ -15,11 +15,11 @@ def main(config: RunConfig) -> None:
     run_checks(config.function)
 
     # Deploy code to Cognite Functions:
-    client = config.deploy_creds.experimental_client
-    fn = upload_and_create_function(client, config.function)
+    deploy_client = config.deploy_creds.experimental_client
+    fn = upload_and_create_function(deploy_client, config.function)
 
     # Deploy schedules (if any):
-    deploy_schedules(client, fn, config.schedule)
+    deploy_schedules(fn, config.schedule)
 
     # Return output parameter (GitHub magic syntax):
     print(f"::set-output name=function_external_id::{fn.external_id}")

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -1,6 +1,5 @@
 import logging
 
-from cognite.experimental import CogniteClient
 from cognite.experimental.data_classes import Function
 
 from configs import SchedulesConfig
@@ -8,12 +7,13 @@ from configs import SchedulesConfig
 logger = logging.getLogger(__name__)
 
 
-def deploy_schedules(client: CogniteClient, fn: Function, schedule_config: SchedulesConfig):
+def deploy_schedules(fn: Function, schedule_config: SchedulesConfig):
     if not (schedules := schedule_config.schedules):
         logger.info("No schedules to attach to function!")
         return
 
     logger.info(f"Attaching {len(schedules)} schedule(s) to {fn.external_id} (by ID: {fn.id})")
+    client = schedule_config.experimental_client
     for s in schedules:
         client.functions.schedules.create(
             function_id=fn.id,


### PR DESCRIPTION
So, as it turns out - deploy credentials does not need `sessions:CREATE` - which I originally thought - the problem was just that the same credentials were used for schedules creation... (as can be seen in the code), _and not the one actually_ meant for schedules (`client_credentials=schedule_config.credentials`) (which was actually passed, wtf).

PIggybacked some ACL-word-capitalizations.