### PR TITLE
Add a best-effort is-token-url-set check

### DIFF
--- a/src/checks.py
+++ b/src/checks.py
@@ -1,8 +1,11 @@
 import ast
 import logging
+from contextlib import suppress
 from pathlib import Path
 
-from configs import FunctionConfig
+from cognite.client.exceptions import CogniteAPIError, CogniteAPIKeyError
+
+from configs import RunConfig
 from exceptions import FunctionValidationError
 
 logger = logging.getLogger(__name__)
@@ -11,10 +14,47 @@ logger = logging.getLogger(__name__)
 HANDLE_ARGS = ("data", "client", "secrets", "function_call_info")
 
 
-def run_checks(config: FunctionConfig) -> None:
+def run_checks(config: RunConfig) -> None:
+    # Check 'token_url' is set if we have `Projects:READ`:
+    _check_token_url_is_set(config)
+
     # Python-only checks:
-    if config.function_file.endswith(".py"):
-        _check_handle_args(config.function_folder / config.function_file)
+    fn_config = config.function
+    if fn_config.function_file.endswith(".py"):
+        _check_handle_args(fn_config.function_folder / fn_config.function_file)
+
+
+def _check_token_url_is_set(config: RunConfig):
+    """
+    If one of the users credentials happens to have ProjectsAcl:READ, we can verify that
+    token URL has been set correctly for the project. Since this Acl is not a requirement for
+    functions deployment, we do not raise if missing.
+    """
+    clients = [config.deploy_creds.experimental_client]
+    with suppress(CogniteAPIKeyError):
+        # If user is adding schedules, we have additional credentials to try with:
+        clients.append(config.schedule.experimental_client)
+
+    for client in clients:
+        project = client.config.project
+        tenant_id = config.deploy_creds.tenant_id
+        try:
+            resp = client.get(url=f"/api/v1/projects/{project}")
+        except CogniteAPIError:
+            continue
+
+        oidc_config = resp.json()["oidcConfiguration"]
+        token_url = oidc_config.get("tokenUrl")
+        if token_url is not None and tenant_id in token_url:
+            return
+        else:
+            err_msg = (
+                f"Project '{project}' OpenID Connect configuration has no token URL. You can fix this by "
+                "going to Fusion, Access Management, OpenID Connect then adding the missing field "
+                "(Note: Requires `ProjectsAcl:UPDATE`)."
+            )
+            logger.error(err_msg)
+            raise FunctionValidationError(err_msg)
 
 
 def _check_handle_args(file_path: Path, fn_name: str = "handle") -> None:

--- a/src/function_file.py
+++ b/src/function_file.py
@@ -62,7 +62,7 @@ def zip_and_upload_folder(client: CogniteClient, fn_config: FunctionConfig, xid:
     if (ds_id := fn_config.data_set_id) is not None:
         ds = retrieve_dataset(client, ds_id)
         logger.info(
-            f"- Using dataset '{ds.external_id}' (ID: {ds_id}) to govern the file "
+            f"- Using dataset '{ds.name}' (ID: {ds_id}) to govern the file "
             f"(has write protection: {ds.write_protected})."
         )
     else:

--- a/src/index.py
+++ b/src/index.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def main(config: RunConfig) -> None:
     # Run static analysis / other checks and pre-deployment verifications:
-    run_checks(config.function)
+    run_checks(config)
 
     # Deploy code to Cognite Functions:
     deploy_client = config.deploy_creds.experimental_client


### PR DESCRIPTION
Most projects set up for OIDC does not populate the `tokenUrl` field. This causes problems later on with schedules and function calls using OIDC. This PR adds a "best effort" check on whether this is set or not. Best effort meaning if the users credentials have `projects:READ`, we check - and possibly raise - but if missing, we do nothing.

Example: https://cognitedata.slack.com/archives/C010VCGKBCM/p1632300275143500
FYI: @senickel might be something in here interesting for AIR.