### PR TITLE
Credentials may have access to multiple CDF projects, fml

### DIFF
--- a/src/configs.py
+++ b/src/configs.py
@@ -7,7 +7,7 @@ from crontab import CronSlices
 from pydantic import BaseModel, Field, Json, NonNegativeInt, root_validator, validator
 from yaml import safe_load  # type: ignore
 
-from access import verify_credentials_vs_project, verify_deploy_capabilites, verify_schedule_creds_capabilities
+from access import verify_deploy_capabilites, verify_schedule_creds_capabilities
 from defaults import (
     DEFAULT_FUNCTION_DEPLOY_TIMEOUT,
     DEFAULT_FUNCTION_FILE,
@@ -91,7 +91,6 @@ class DeployCredentials(GithubActionModel, CredentialsModel):
         project = values["cdf_project"]
         data_set_id = values["data_set_id"]
         verify_deploy_capabilites(client, project, ds_id=data_set_id)
-        verify_credentials_vs_project(client, project, cred_name="deploy")
         return values
 
 
@@ -133,7 +132,6 @@ class SchedulesConfig(GithubActionModel, CredentialsModel):
         client = create_oidc_client_from_dct(values)
         project = values["cdf_project"]
         verify_schedule_creds_capabilities(client, project)
-        verify_credentials_vs_project(client, project, cred_name="schedule")
         return values
 
 

--- a/src/function.py
+++ b/src/function.py
@@ -61,7 +61,7 @@ def create_function(client: CogniteClient, file_id: int, fn_config: FunctionConf
         logger.info("...with no extra secrets")
 
     fn = client.functions.create(file_id=file_id, **fn_config.create_fn_params())
-    logging.info(f"Function '{fn_xid}' created and queued for deployment! (ID: {fn.id}).")
+    logger.info(f"Function '{fn_xid}' created and queued for deployment! (ID: {fn.id}).")
     return fn
 
 


### PR DESCRIPTION
For service accounts with access to multiple CDF projects, but with missing `projects:LIST` in some of them, _but not all_, running `token/inspect` will not fail (a check we used to rely on). Now the "project is in listed projects" check has been merged into the same function so that we may notify the user with the correct error message, namely missing capability `projects:LIST`.