### PR TITLE
Update docs with changes to how `cpu/memory` is treated on CDF projects on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ All optional parameters that has default values, can be found in `src/defaults.p
 1. `description`: Additional field to describe the function.
 1. `owner`: Additional field to describe the function owner.
 1. `env_vars`: Environment variables for your function. Accepts JSON with string key/value pairs, like `{"FOO_BAR": "baz", "another_env_var": "cool"}`.
-1. `cpu`: Set fractional number of CPU cores per function. **Ignored for functions running on Azure!**. See defaults and allowed values in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).
-1. `memory`: Set memory per function measured in GB. **Ignored for functions running on Azure!**. See defaults and allowed values in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).
-1. `runtime`: The function runtime. See defaults and allowed values in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).
+1. `cpu`: Set fractional number of CPU cores per function. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the: [Functions API documentation](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
+1. `memory`: Set memory per function measured in GB. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the: [Functions API documentation](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
+1. `runtime`: The function runtime. Check the default and allowed values/versions in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).
 
 
 ### Schedule file format [`.yaml`]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ All optional parameters that has default values, can be found in `src/defaults.p
 1. `description`: Additional field to describe the function.
 1. `owner`: Additional field to describe the function owner.
 1. `env_vars`: Environment variables for your function. Accepts JSON with string key/value pairs, like `{"FOO_BAR": "baz", "another_env_var": "cool"}`.
-1. `cpu`: Set fractional number of CPU cores per function. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the: [Functions API documentation](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
-1. `memory`: Set memory per function measured in GB. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the: [Functions API documentation](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
+1. `cpu`: Set fractional number of CPU cores per function. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the [Functions API (documentation)](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
+1. `memory`: Set memory per function measured in GB. You may check the default and the allowed values (they vary with the CDF project's cloud provider) by calling the `/limits` endpoint of the [Functions API (documentation)](https://docs.cognite.com/api/playground/#operation/get-functions-limits).
 1. `runtime`: The function runtime. Check the default and allowed values/versions in the [API documentation](https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions).
 
 

--- a/action.yaml
+++ b/action.yaml
@@ -78,10 +78,10 @@ inputs:
             deleted after the Function has been successfully created.
         required: false
     cpu:
-        description: 'Set number of CPU cores per function, e.g. 0.5. NB: Ignored for CDF projects on Azure!'
+        description: 'Set number of CPU cores per function, e.g. 0.5.'
         required: false
     memory:
-        description: 'Set memory per function measured in GB, e.g. 0.8. NB: Ignored for CDF projects on Azure!'
+        description: 'Set memory per function measured in GB, e.g. 0.8.'
         required: false
     owner:
         description: Set owner of a function, e.g. "My Client".

--- a/src/configs.py
+++ b/src/configs.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from crontab import CronSlices
-from pydantic import BaseModel, Field, Json, NonNegativeInt, root_validator, validator
+from pydantic import BaseModel, Field, Json, NonNegativeFloat, NonNegativeInt, root_validator, validator
 from yaml import safe_load  # type: ignore
 
 from access import verify_deploy_capabilites, verify_schedule_creds_capabilities
@@ -163,8 +163,8 @@ class FunctionConfig(GithubActionModel):
     common_folder: Optional[Path]
     post_deploy_cleanup: bool = DEFAULT_POST_DEPLOY_CLEANUP
     data_set_id: Optional[int]
-    cpu: Optional[float]
-    memory: Optional[float]
+    cpu: Optional[NonNegativeFloat]
+    memory: Optional[NonNegativeFloat]
     owner: Optional[NonEmptyStringMax128]
     description: Optional[NonEmptyStringMax128]
     env_vars: Optional[Json[Dict[str, str]]]

--- a/src/configs.py
+++ b/src/configs.py
@@ -18,6 +18,7 @@ from utils import (
     FnFileString,
     NonEmptyString,
     NonEmptyStringMax128,
+    NonEmptyStringMax500,
     ToLowerStr,
     YamlFileString,
     create_oidc_client_from_dct,
@@ -166,7 +167,7 @@ class FunctionConfig(GithubActionModel):
     cpu: Optional[NonNegativeFloat]
     memory: Optional[NonNegativeFloat]
     owner: Optional[NonEmptyStringMax128]
-    description: Optional[NonEmptyStringMax128]
+    description: Optional[NonEmptyStringMax500]
     env_vars: Optional[Json[Dict[str, str]]]
     runtime: Optional[ToLowerStr]
 

--- a/src/index.py
+++ b/src/index.py
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 
 def main(config: RunConfig) -> None:
     # Run static analysis / other checks and pre-deployment verifications:
-    run_checks(config.function)
+    deploy_client = config.deploy_creds.experimental_client
+    run_checks(config.function, deploy_client)
 
     # Deploy code directory to Cognite Functions with schedules (if any)
     # and await successful deployment:
-    deploy_client = config.deploy_creds.experimental_client
     fn = upload_and_create_function(deploy_client, config.function)
     deploy_schedules(fn, config.schedule)
     run_cleanup(fn, config.function)

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 ToLowerStr = constr(to_lower=True, strip_whitespace=True)
 NonEmptyString = constr(min_length=1, strip_whitespace=True)
 NonEmptyStringMax128 = constr(min_length=1, max_length=128, strip_whitespace=True)
+NonEmptyStringMax500 = constr(min_length=1, max_length=500, strip_whitespace=True)
 YamlFileString = constr(min_length=1, strip_whitespace=True, regex=r"^[\w\- /]+\.ya?ml$")  # noqa: F722
 FnFileString = constr(min_length=1, strip_whitespace=True, regex=r"^[\w\- ]+\.(py|js)$")  # noqa: F722
 


### PR DESCRIPTION
Also adds a warn-only check on parameters: `cpu`, `memory` and `runtime`. 

The reasoning for checking this at all, is that the actual limits might be a bit hard to find - as they vary with the underlying cloud provider CDF is running on - and they require a call to `FunctionsAPI/limits/get` (documentation currently only reflects projects on GCP). We still only send out a warning though - but with the reported numbers for the user's convenience.