### PR TITLE
Add retry on specific API status codes for function/create

### DIFF
--- a/src/function_file.py
+++ b/src/function_file.py
@@ -85,8 +85,8 @@ def delete_function_file(client: CogniteClient, xid: str):
     try:
         client.files.delete(external_id=xid)
         logger.info(f"- Delete of file '{xid}' successful!")
-    except CogniteAPIError as err:
-        reason = f"{type(err).__name__}: {err}"  # 'CogniteAPIError' does not implement dunder repr...
+    except CogniteAPIError as e:
+        reason = f"{type(e).__name__}({e})"  # 'CogniteAPIError' does not implement dunder repr...
         logger.error(
             "Unable to delete file! Trying to ignore and continue as this action will overwrite "
             f"the file later. Error message from the API: \n{reason}"


### PR DESCRIPTION
Instead of doing "add CogniteAPIError to @retry decorator", I'd like us to only retry specific codes, without re-running the entire pipeline.

ref slack:
https://cognitedata.slack.com/archives/C010VCGKBCM/p1646642586617489?thread_ts=1646415274.966249&cid=C010VCGKBCM