### PR TITLE
replace deprecated syntax

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       name: "Parse version from ref"
       run: | # Returns the last component of the ref path, e.g. 'refs/tags/release/1.2.3-beta' -> '1.2.3-beta'
         $version = split-path -leaf $env:GITHUB_REF
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: "Build and push Docker image"
       uses: docker/build-push-action@v2
       with:

--- a/src/index.py
+++ b/src/index.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from checks import run_checks
 from cleanup import run_cleanup
@@ -22,8 +23,9 @@ def main(config: RunConfig) -> None:
     deploy_schedules(fn, config.schedule)
     run_cleanup(fn, config.function)
 
-    # Return output parameter (GitHub magic syntax):
-    print(f"::set-output name=function_external_id::{fn.external_id}")
+    # Return output parameter:
+    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+        print(f"function_external_id={fn.external_id}", file=fh)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`save-state` and `set-output` will stop working by the end of May: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/