### PR TITLE
Upgrade action to py 3.10

### DIFF
--- a/Dockerfile-azure-pipelines
+++ b/Dockerfile-azure-pipelines
@@ -1,4 +1,4 @@
-FROM python:3.8-slim AS builder
+FROM python:3.10-slim AS builder
 
 ADD src /app
 WORKDIR /
@@ -16,6 +16,6 @@ RUN poetry export -f requirements.txt --output /requirements.txt --without-hashe
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade
 
-FROM python:3.8-buster
+FROM python:3.10-bookworm
 COPY --from=builder /app /app
 ENV PYTHONPATH /app

--- a/Dockerfile-azure-pipelines
+++ b/Dockerfile-azure-pipelines
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS builder
+FROM python:3.11-slim AS builder
 
 ADD src /app
 WORKDIR /
@@ -16,6 +16,6 @@ RUN poetry export -f requirements.txt --output /requirements.txt --without-hashe
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade
 
-FROM python:3.10-bookworm
+FROM python:3.11-bookworm
 COPY --from=builder /app /app
 ENV PYTHONPATH /app

--- a/Dockerfile-github-actions
+++ b/Dockerfile-github-actions
@@ -1,4 +1,4 @@
-FROM python:3.8-slim AS builder
+FROM python:3.10-slim AS builder
 
 ADD src /app
 WORKDIR /
@@ -16,7 +16,7 @@ RUN poetry export -f requirements.txt --output /requirements.txt --without-hashe
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade
 
-FROM python:3.8-buster
+FROM python:3.10-bookworm
 COPY --from=builder /app /app
 ENV PYTHONPATH /app
 CMD ["python", "/app/index.py"]

--- a/Dockerfile-github-actions
+++ b/Dockerfile-github-actions
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS builder
+FROM python:3.11-slim AS builder
 
 ADD src /app
 WORKDIR /
@@ -16,7 +16,7 @@ RUN poetry export -f requirements.txt --output /requirements.txt --without-hashe
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app -r /requirements.txt --upgrade
 
-FROM python:3.10-bookworm
+FROM python:3.11-bookworm
 COPY --from=builder /app /app
 ENV PYTHONPATH /app
 CMD ["python", "/app/index.py"]

--- a/src/checks.py
+++ b/src/checks.py
@@ -73,7 +73,15 @@ def _check_handle_args(file_path: Path, fn_name: str = "handle") -> None:
     with file_path.open() as f:
         file = f.read()
 
-    (node_visitor := HandleVisitor(file_path)).visit(ast.parse(file))
+    try:
+        (node_visitor := HandleVisitor(file_path)).visit(ast.parse(file))
+    except SyntaxError:
+        logger.error(
+            f"Unable to parse file '{file_path}' and check for valid handle args! Please open an issue "
+            "on github.com/cognitedata/function-action-oidc"
+        )
+        return
+
     if not node_visitor.handle_found:
         err_msg = (
             f"Required function named '{fn_name}' was not found in file '{file_path}' "


### PR DESCRIPTION
Functions support py 3.10 but currently the action breaks due to new syntax in 3.10, such as `match` statement.

sample error:
```
Traceback (most recent call last):
  File "/app/index.py", line 55, in <module>
    main(config)
  File "/app/index.py", line 26, in main
    run_checks(config.function, deploy_client)
  File "/app/checks.py", line 20, in run_checks
    _check_handle_args(config.function_folder / config.function_file)
  File "/app/checks.py", line 76, in _check_handle_args
    (node_visitor := HandleVisitor(file_path)).visit(ast.parse(file))
  File "/usr/local/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 27
    match project.split("-")[-1]:
          ^
SyntaxError: invalid syntax
```