### PR TITLE
remove nested common folder restriction

### DIFF
--- a/src/access.py
+++ b/src/access.py
@@ -45,7 +45,7 @@ def retrieve_and_parse_capabilities(client: CogniteClient, project: str) -> List
     return list(
         map(
             Capability.from_dct,
-            (c for group in retrieve_groups_in_user_scope(client) for c in group.capabilities),
+            (c.dump() for group in retrieve_groups_in_user_scope(client) for c in group.capabilities),
         ),
     )
 

--- a/src/configs.py
+++ b/src/configs.py
@@ -216,8 +216,6 @@ class FunctionConfig(GithubActionModel):
             logger.info("No 'common code' directory added to the function!")
         else:
             verify_path_is_directory(common_folder, "common_folder")
-            if len(Path(common_folder).parts) > 1:
-                raise ValueError(f"Common folder: '{common_folder}' cannot be a nested folder")
         return values
 
 


### PR DESCRIPTION
Any idea why this was added? I've tested a lot with my github workflow and it doesn't break when these lines are removed.